### PR TITLE
Fixed build badge / Improved Gulp file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## country-data  [![Build Status](https://api.travis-ci.org/samayo/country-data.svg)](https://travis-ci.org/samayo/country-data)
+## country-data  [![Build Status](https://travis-ci.org/samayo/country-data.svg?branch=master)](https://travis-ci.org/samayo/country-data)
 
 A simple but useful data of the world (by country) in JSON format.
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,7 +12,7 @@ gulp.task('lint', function () {
 // Custom reporter for jsonlint to ensure Gulp exits correctly on fail for Travis tests.
 var failReporter = function (file) {
   if (file.jsonlint && !file.jsonlint.success) {
-    throw new gutil.PluginError('gulp-jsonlint', 'jsonlint failed for ' + file.relative);
+    throw new gutil.PluginError('gulp-jsonlint', file.jsonlint.message);
   }
 };
 


### PR DESCRIPTION
I noticed that the build was failing for your dev branch and was causing the master branch to look like it was failing in the readme. I've updated the build badge to only show the status of master to resolve this.

I've also modified the Gulp file so that errors are better reported in Travis to help make it easier to fix a broken build.