### PR TITLE
Corrected spelling of Bulgaria's capital

### DIFF
--- a/src/country-capital-city.json
+++ b/src/country-capital-city.json
@@ -31,7 +31,7 @@
 {"country" : "Brazil","city" : "Bras"},
 {"country" : "British Indian Ocean Territory","city" : ""},
 {"country" : "Brunei","city" : "Bandar Seri Begawan"},
-{"country" : "Bulgaria","city" : "Sofija"},
+{"country" : "Bulgaria","city" : "Sofia"},
 {"country" : "Burkina Faso","city" : "Ouagadougou"},
 {"country" : "Burundi","city" : "Bujumbura"},
 {"country" : "Cambodia","city" : "Phnom Penh"},


### PR DESCRIPTION
Sofia (София) is the name of the city.